### PR TITLE
Implement CRUD operations as REST API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,50 +6,47 @@
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>3.4.1</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<relativePath/>
 	</parent>
 	<groupId>ua.yatsergray</groupId>
 	<artifactId>FootballManager</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>FootballManager</name>
 	<description>FootballManager</description>
-	<url/>
-	<licenses>
-		<license/>
-	</licenses>
-	<developers>
-		<developer/>
-	</developers>
-	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
-	</scm>
+
 	<properties>
 		<java.version>17</java.version>
+		<org.mapstruct.version>1.5.5.Final</org.mapstruct.version>
+		<org.lombok.version>1.18.30</org.lombok.version>
+		<com.amazonaws.version>1.12.375</com.amazonaws.version>
 	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jdbc</artifactId>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
+
 		<dependency>
 			<groupId>org.flywaydb</groupId>
 			<artifactId>flyway-core</artifactId>
 		</dependency>
+
 		<dependency>
 			<groupId>org.flywaydb</groupId>
 			<artifactId>flyway-database-postgresql</artifactId>
@@ -61,16 +58,26 @@
 			<scope>runtime</scope>
 			<optional>true</optional>
 		</dependency>
+
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>
 		</dependency>
+
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<version>${org.lombok.version}</version>
 			<optional>true</optional>
 		</dependency>
+
+		<dependency>
+			<groupId>org.mapstruct</groupId>
+			<artifactId>mapstruct</artifactId>
+			<version>${org.mapstruct.version}</version>
+		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
@@ -83,15 +90,32 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.1</version>
 				<configuration>
+					<source>${java.version}</source>
+					<target>${java.version}</target>
 					<annotationProcessorPaths>
+						<path>
+							<groupId>org.mapstruct</groupId>
+							<artifactId>mapstruct-processor</artifactId>
+							<version>${org.mapstruct.version}</version>
+						</path>
+
 						<path>
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
+							<version>${org.lombok.version}</version>
+						</path>
+
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok-mapstruct-binding</artifactId>
+							<version>0.1.0</version>
 						</path>
 					</annotationProcessorPaths>
 				</configuration>
 			</plugin>
+
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>

--- a/src/main/java/ua/yatsergray/football/manager/controller/PlayerController.java
+++ b/src/main/java/ua/yatsergray/football/manager/controller/PlayerController.java
@@ -1,0 +1,57 @@
+package ua.yatsergray.football.manager.controller;
+
+import jakarta.validation.Valid;
+import lombok.SneakyThrows;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import ua.yatsergray.football.manager.domain.dto.PlayerDTO;
+import ua.yatsergray.football.manager.domain.request.PlayerCreateRequest;
+import ua.yatsergray.football.manager.domain.request.PlayerUpdateRequest;
+import ua.yatsergray.football.manager.service.impl.PlayerServiceImpl;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/players")
+public class PlayerController {
+    private final PlayerServiceImpl playerService;
+
+    @Autowired
+    public PlayerController(PlayerServiceImpl playerService) {
+        this.playerService = playerService;
+    }
+
+    @SneakyThrows
+    @PostMapping
+    public ResponseEntity<PlayerDTO> createPlayer(@Valid @RequestBody PlayerCreateRequest playerCreateRequest) {
+        return ResponseEntity.ok(playerService.addPlayer(playerCreateRequest));
+    }
+
+    @GetMapping("/{playerId}")
+    public ResponseEntity<PlayerDTO> readPlayerById(@PathVariable("playerId") UUID playerId) {
+        return playerService.getPlayerById(playerId)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @GetMapping
+    public ResponseEntity<List<PlayerDTO>> readAllPlayers() {
+        return ResponseEntity.ok(playerService.getAllPlayers());
+    }
+
+    @SneakyThrows
+    @PutMapping("/{playerId}")
+    public ResponseEntity<PlayerDTO> updatePlayerById(@PathVariable("playerId") UUID playerId, @Valid @RequestBody PlayerUpdateRequest playerUpdateRequest) {
+        return ResponseEntity.ok(playerService.modifyPlayerById(playerId, playerUpdateRequest));
+    }
+
+    @SneakyThrows
+    @DeleteMapping("/{playerId}")
+    public ResponseEntity<Void> deletePlayerById(@PathVariable("playerId") UUID playerId) {
+        playerService.removePlayerById(playerId);
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/ua/yatsergray/football/manager/controller/TeamController.java
+++ b/src/main/java/ua/yatsergray/football/manager/controller/TeamController.java
@@ -1,0 +1,56 @@
+package ua.yatsergray.football.manager.controller;
+
+import jakarta.validation.Valid;
+import lombok.SneakyThrows;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import ua.yatsergray.football.manager.domain.dto.TeamDTO;
+import ua.yatsergray.football.manager.domain.request.TeamCreateUpdateRequest;
+import ua.yatsergray.football.manager.service.impl.TeamServiceImpl;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/teams")
+public class TeamController {
+    private final TeamServiceImpl teamService;
+
+    @Autowired
+    public TeamController(TeamServiceImpl teamService) {
+        this.teamService = teamService;
+    }
+
+    @SneakyThrows
+    @PostMapping
+    public ResponseEntity<TeamDTO> createTeam(@Valid @RequestBody TeamCreateUpdateRequest teamCreateUpdateRequest) {
+        return ResponseEntity.ok(teamService.addTeam(teamCreateUpdateRequest));
+    }
+
+    @GetMapping("/{teamId}")
+    public ResponseEntity<TeamDTO> readTeamById(@PathVariable("teamId") UUID teamId) {
+        return teamService.getTeamById(teamId)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @GetMapping
+    public ResponseEntity<List<TeamDTO>> readAllTeams() {
+        return ResponseEntity.ok(teamService.getAllTeams());
+    }
+
+    @SneakyThrows
+    @PutMapping("/{teamId}")
+    public ResponseEntity<TeamDTO> updateTeamById(@PathVariable("teamId") UUID teamId, @Valid @RequestBody TeamCreateUpdateRequest teamCreateUpdateRequest) {
+        return ResponseEntity.ok(teamService.modifyTeamById(teamId, teamCreateUpdateRequest));
+    }
+
+    @SneakyThrows
+    @DeleteMapping("/{teamId}")
+    public ResponseEntity<Void> deleteTeamById(@PathVariable("teamId") UUID teamId) {
+        teamService.removeTeamById(teamId);
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/ua/yatsergray/football/manager/domain/dto/PlayerDTO.java
+++ b/src/main/java/ua/yatsergray/football/manager/domain/dto/PlayerDTO.java
@@ -1,0 +1,18 @@
+package ua.yatsergray.football.manager.domain.dto;
+
+import lombok.*;
+
+import java.util.UUID;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+public class PlayerDTO {
+    private UUID id;
+    private String firstName;
+    private String lastName;
+    private Integer age;
+    private Integer monthsOfExperience;
+}

--- a/src/main/java/ua/yatsergray/football/manager/domain/dto/TeamDTO.java
+++ b/src/main/java/ua/yatsergray/football/manager/domain/dto/TeamDTO.java
@@ -1,0 +1,25 @@
+package ua.yatsergray.football.manager.domain.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+public class TeamDTO {
+    private UUID id;
+    private String name;
+    private Integer commissionPercentage;
+    private BigDecimal bankAccountBalance;
+
+    @JsonProperty("players")
+    @Builder.Default
+    private List<PlayerDTO> playerDTOList = new ArrayList<>();
+}

--- a/src/main/java/ua/yatsergray/football/manager/domain/entity/Player.java
+++ b/src/main/java/ua/yatsergray/football/manager/domain/entity/Player.java
@@ -1,0 +1,54 @@
+package ua.yatsergray.football.manager.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.proxy.HibernateProxy;
+
+import java.util.Objects;
+import java.util.UUID;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+@Entity
+@Table(name = "players")
+public class Player {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "first_name", nullable = false)
+    private String firstName;
+
+    @Column(name = "last_name", nullable = false)
+    private String lastName;
+
+    @Column(name = "age", nullable = false)
+    private Integer age;
+
+    @Column(name = "months_of_experience", nullable = false)
+    private Integer monthsOfExperience;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id", nullable = false)
+    private Team team;
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        Class<?> oEffectiveClass = o instanceof HibernateProxy ? ((HibernateProxy) o).getHibernateLazyInitializer().getPersistentClass() : o.getClass();
+        Class<?> thisEffectiveClass = this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass() : this.getClass();
+        if (thisEffectiveClass != oEffectiveClass) return false;
+        Player player = (Player) o;
+        return getId() != null && Objects.equals(getId(), player.getId());
+    }
+
+    @Override
+    public final int hashCode() {
+        return this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass().hashCode() : getClass().hashCode();
+    }
+}

--- a/src/main/java/ua/yatsergray/football/manager/domain/entity/Team.java
+++ b/src/main/java/ua/yatsergray/football/manager/domain/entity/Team.java
@@ -1,0 +1,54 @@
+package ua.yatsergray.football.manager.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.proxy.HibernateProxy;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+@Entity
+@Table(name = "teams")
+public class Team {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "name", unique = true, nullable = false)
+    private String name;
+
+    @Column(name = "commission_percentage", nullable = false)
+    private Integer commissionPercentage;
+
+    @Column(name = "bank_account_balance", nullable = false, precision = 19, scale = 2)
+    private BigDecimal bankAccountBalance;
+
+    @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private Set<Player> players = new LinkedHashSet<>();
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        Class<?> oEffectiveClass = o instanceof HibernateProxy ? ((HibernateProxy) o).getHibernateLazyInitializer().getPersistentClass() : o.getClass();
+        Class<?> thisEffectiveClass = this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass() : this.getClass();
+        if (thisEffectiveClass != oEffectiveClass) return false;
+        Team team = (Team) o;
+        return getId() != null && Objects.equals(getId(), team.getId());
+    }
+
+    @Override
+    public final int hashCode() {
+        return this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass().hashCode() : getClass().hashCode();
+    }
+}

--- a/src/main/java/ua/yatsergray/football/manager/domain/request/PlayerCreateRequest.java
+++ b/src/main/java/ua/yatsergray/football/manager/domain/request/PlayerCreateRequest.java
@@ -1,0 +1,34 @@
+package ua.yatsergray.football.manager.domain.request;
+
+import jakarta.validation.constraints.*;
+import lombok.*;
+
+import java.util.UUID;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+public class PlayerCreateRequest {
+
+    @NotBlank(message = "First name is mandatory")
+    @Size(min = 2, max = 50, message = "First name must be between 2 and 50 characters")
+    private String firstName;
+
+    @NotBlank(message = "Last name is mandatory")
+    @Size(min = 2, max = 50, message = "Last name must be between 2 and 50 characters")
+    private String lastName;
+
+    @NotNull(message = "Age is mandatory")
+    @Min(value = 18, message = "Age must be at least 18")
+    @Max(value = 100, message = "Age must not exceed 100")
+    private Integer age;
+
+    @NotNull(message = "Months of experience are mandatory")
+    @Positive(message = "Months of experience must be greater than 0")
+    private Integer monthsOfExperience;
+
+    @NotNull(message = "Team id is mandatory")
+    private UUID teamId;
+}

--- a/src/main/java/ua/yatsergray/football/manager/domain/request/PlayerUpdateRequest.java
+++ b/src/main/java/ua/yatsergray/football/manager/domain/request/PlayerUpdateRequest.java
@@ -1,0 +1,29 @@
+package ua.yatsergray.football.manager.domain.request;
+
+import jakarta.validation.constraints.*;
+import lombok.*;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+public class PlayerUpdateRequest {
+
+    @NotBlank(message = "First name is mandatory")
+    @Size(min = 2, max = 50, message = "First name must be between 2 and 50 characters")
+    private String firstName;
+
+    @NotBlank(message = "Last name is mandatory")
+    @Size(min = 2, max = 50, message = "Last name must be between 2 and 50 characters")
+    private String lastName;
+
+    @NotNull(message = "Age is mandatory")
+    @Min(value = 18, message = "Age must be at least 18")
+    @Max(value = 100, message = "Age must not exceed 100")
+    private Integer age;
+
+    @NotNull(message = "Months of experience are mandatory")
+    @Positive(message = "Months of experience must be greater than 0")
+    private Integer monthsOfExperience;
+}

--- a/src/main/java/ua/yatsergray/football/manager/domain/request/TeamCreateUpdateRequest.java
+++ b/src/main/java/ua/yatsergray/football/manager/domain/request/TeamCreateUpdateRequest.java
@@ -1,0 +1,28 @@
+package ua.yatsergray.football.manager.domain.request;
+
+import jakarta.validation.constraints.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+public class TeamCreateUpdateRequest {
+
+    @NotBlank(message = "Name is mandatory")
+    @Size(min = 2, max = 50, message = "Name must be between 2 and 50 characters")
+    private String name;
+
+    @NotNull(message = "Commission percentage is mandatory")
+    @Min(value = 0, message = "Commission percentage must be at least 0")
+    @Max(value = 10, message = "Commission percentage must not exceed 10")
+    private Integer commissionPercentage;
+
+    @NotNull(message = "Bank account balance is mandatory")
+    @DecimalMin(value = "0.00", message = "Bank account balance must be at least 0")
+    @Digits(integer = 17, fraction = 2, message = "Bank account balance must have up to 17 integer digits and 2 fractional digits")
+    private BigDecimal bankAccountBalance;
+}

--- a/src/main/java/ua/yatsergray/football/manager/exception/NoSuchPlayerException.java
+++ b/src/main/java/ua/yatsergray/football/manager/exception/NoSuchPlayerException.java
@@ -1,0 +1,8 @@
+package ua.yatsergray.football.manager.exception;
+
+public class NoSuchPlayerException extends Exception {
+
+    public NoSuchPlayerException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/ua/yatsergray/football/manager/exception/NoSuchTeamException.java
+++ b/src/main/java/ua/yatsergray/football/manager/exception/NoSuchTeamException.java
@@ -1,0 +1,8 @@
+package ua.yatsergray.football.manager.exception;
+
+public class NoSuchTeamException extends Exception {
+
+    public NoSuchTeamException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/ua/yatsergray/football/manager/exception/TeamAlreadyExistsException.java
+++ b/src/main/java/ua/yatsergray/football/manager/exception/TeamAlreadyExistsException.java
@@ -1,0 +1,8 @@
+package ua.yatsergray.football.manager.exception;
+
+public class TeamAlreadyExistsException extends Exception {
+
+    public TeamAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/ua/yatsergray/football/manager/handler/PlayerExceptionHandler.java
+++ b/src/main/java/ua/yatsergray/football/manager/handler/PlayerExceptionHandler.java
@@ -1,0 +1,15 @@
+package ua.yatsergray.football.manager.handler;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import ua.yatsergray.football.manager.exception.NoSuchPlayerException;
+
+@ControllerAdvice
+public class PlayerExceptionHandler {
+
+    @ExceptionHandler(NoSuchPlayerException.class)
+    public ResponseEntity<String> handleNoSuchPlayerException(NoSuchPlayerException e) {
+        return ResponseEntity.badRequest().body(e.getMessage());
+    }
+}

--- a/src/main/java/ua/yatsergray/football/manager/handler/TeamExceptionHandler.java
+++ b/src/main/java/ua/yatsergray/football/manager/handler/TeamExceptionHandler.java
@@ -1,0 +1,21 @@
+package ua.yatsergray.football.manager.handler;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import ua.yatsergray.football.manager.exception.NoSuchTeamException;
+import ua.yatsergray.football.manager.exception.TeamAlreadyExistsException;
+
+@ControllerAdvice
+public class TeamExceptionHandler {
+
+    @ExceptionHandler(NoSuchTeamException.class)
+    public ResponseEntity<String> handleNoSuchTeamException(NoSuchTeamException e) {
+        return ResponseEntity.badRequest().body(e.getMessage());
+    }
+
+    @ExceptionHandler(TeamAlreadyExistsException.class)
+    public ResponseEntity<String> handleTeamAlreadyExistsException(TeamAlreadyExistsException e) {
+        return ResponseEntity.badRequest().body(e.getMessage());
+    }
+}

--- a/src/main/java/ua/yatsergray/football/manager/handler/ValidationExceptionHandler.java
+++ b/src/main/java/ua/yatsergray/football/manager/handler/ValidationExceptionHandler.java
@@ -1,0 +1,23 @@
+package ua.yatsergray.football.manager.handler;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@ControllerAdvice
+public class ValidationExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleValidationExceptions(MethodArgumentNotValidException e) {
+        Map<String, String> errors = new HashMap<>();
+
+        e.getBindingResult().getFieldErrors()
+                .forEach(error -> errors.put(error.getField(), error.getDefaultMessage()));
+
+        return ResponseEntity.badRequest().body(errors);
+    }
+}

--- a/src/main/java/ua/yatsergray/football/manager/mapper/PlayerMapper.java
+++ b/src/main/java/ua/yatsergray/football/manager/mapper/PlayerMapper.java
@@ -1,0 +1,18 @@
+package ua.yatsergray.football.manager.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+import ua.yatsergray.football.manager.domain.dto.PlayerDTO;
+import ua.yatsergray.football.manager.domain.entity.Player;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface PlayerMapper {
+
+    PlayerMapper INSTANCE = Mappers.getMapper(PlayerMapper.class);
+
+    PlayerDTO mapToPlayerDTO(Player player);
+
+    List<PlayerDTO> mapAllToPlayerDTOList(List<Player> players);
+}

--- a/src/main/java/ua/yatsergray/football/manager/mapper/TeamMapper.java
+++ b/src/main/java/ua/yatsergray/football/manager/mapper/TeamMapper.java
@@ -1,0 +1,20 @@
+package ua.yatsergray.football.manager.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+import ua.yatsergray.football.manager.domain.dto.TeamDTO;
+import ua.yatsergray.football.manager.domain.entity.Team;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring", uses = PlayerMapper.class)
+public interface TeamMapper {
+
+    TeamMapper INSTANCE = Mappers.getMapper(TeamMapper.class);
+
+    @Mapping(source = "players", target = "playerDTOList")
+    TeamDTO mapToTeamDTO(Team team);
+
+    List<TeamDTO> mapAllToTeamDTOList(List<Team> teams);
+}

--- a/src/main/java/ua/yatsergray/football/manager/repository/PlayerRepository.java
+++ b/src/main/java/ua/yatsergray/football/manager/repository/PlayerRepository.java
@@ -1,0 +1,11 @@
+package ua.yatsergray.football.manager.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import ua.yatsergray.football.manager.domain.entity.Player;
+
+import java.util.UUID;
+
+@Repository
+public interface PlayerRepository extends JpaRepository<Player, UUID> {
+}

--- a/src/main/java/ua/yatsergray/football/manager/repository/TeamRepository.java
+++ b/src/main/java/ua/yatsergray/football/manager/repository/TeamRepository.java
@@ -1,0 +1,13 @@
+package ua.yatsergray.football.manager.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import ua.yatsergray.football.manager.domain.entity.Team;
+
+import java.util.UUID;
+
+@Repository
+public interface TeamRepository extends JpaRepository<Team, UUID> {
+
+    boolean existsByName(String teamName);
+}

--- a/src/main/java/ua/yatsergray/football/manager/service/PlayerService.java
+++ b/src/main/java/ua/yatsergray/football/manager/service/PlayerService.java
@@ -1,0 +1,24 @@
+package ua.yatsergray.football.manager.service;
+
+import ua.yatsergray.football.manager.domain.dto.PlayerDTO;
+import ua.yatsergray.football.manager.domain.request.PlayerCreateRequest;
+import ua.yatsergray.football.manager.domain.request.PlayerUpdateRequest;
+import ua.yatsergray.football.manager.exception.NoSuchPlayerException;
+import ua.yatsergray.football.manager.exception.NoSuchTeamException;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface PlayerService {
+
+    PlayerDTO addPlayer(PlayerCreateRequest playerCreateRequest) throws NoSuchTeamException;
+
+    Optional<PlayerDTO> getPlayerById(UUID playerId);
+
+    List<PlayerDTO> getAllPlayers();
+
+    PlayerDTO modifyPlayerById(UUID playerId, PlayerUpdateRequest playerUpdateRequest) throws NoSuchPlayerException;
+
+    void removePlayerById(UUID playerId) throws NoSuchPlayerException;
+}

--- a/src/main/java/ua/yatsergray/football/manager/service/TeamService.java
+++ b/src/main/java/ua/yatsergray/football/manager/service/TeamService.java
@@ -1,0 +1,23 @@
+package ua.yatsergray.football.manager.service;
+
+import ua.yatsergray.football.manager.domain.dto.TeamDTO;
+import ua.yatsergray.football.manager.domain.request.TeamCreateUpdateRequest;
+import ua.yatsergray.football.manager.exception.NoSuchTeamException;
+import ua.yatsergray.football.manager.exception.TeamAlreadyExistsException;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface TeamService {
+
+    TeamDTO addTeam(TeamCreateUpdateRequest teamCreateUpdateRequest) throws TeamAlreadyExistsException;
+
+    Optional<TeamDTO> getTeamById(UUID teamId);
+
+    List<TeamDTO> getAllTeams();
+
+    TeamDTO modifyTeamById(UUID teamId, TeamCreateUpdateRequest teamCreateUpdateRequest) throws NoSuchTeamException, TeamAlreadyExistsException;
+
+    void removeTeamById(UUID teamId) throws NoSuchTeamException;
+}

--- a/src/main/java/ua/yatsergray/football/manager/service/impl/PlayerServiceImpl.java
+++ b/src/main/java/ua/yatsergray/football/manager/service/impl/PlayerServiceImpl.java
@@ -1,0 +1,81 @@
+package ua.yatsergray.football.manager.service.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import ua.yatsergray.football.manager.domain.dto.PlayerDTO;
+import ua.yatsergray.football.manager.domain.entity.Player;
+import ua.yatsergray.football.manager.domain.entity.Team;
+import ua.yatsergray.football.manager.domain.request.PlayerCreateRequest;
+import ua.yatsergray.football.manager.domain.request.PlayerUpdateRequest;
+import ua.yatsergray.football.manager.exception.NoSuchPlayerException;
+import ua.yatsergray.football.manager.exception.NoSuchTeamException;
+import ua.yatsergray.football.manager.mapper.PlayerMapper;
+import ua.yatsergray.football.manager.repository.PlayerRepository;
+import ua.yatsergray.football.manager.repository.TeamRepository;
+import ua.yatsergray.football.manager.service.PlayerService;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class PlayerServiceImpl implements PlayerService {
+    private final PlayerMapper playerMapper;
+    private final PlayerRepository playerRepository;
+    private final TeamRepository teamRepository;
+
+    @Autowired
+    public PlayerServiceImpl(PlayerMapper playerMapper, PlayerRepository playerRepository, TeamRepository teamRepository) {
+        this.playerMapper = playerMapper;
+        this.playerRepository = playerRepository;
+        this.teamRepository = teamRepository;
+    }
+
+    @Override
+    public PlayerDTO addPlayer(PlayerCreateRequest playerCreateRequest) throws NoSuchTeamException {
+        Team team = teamRepository.findById(playerCreateRequest.getTeamId())
+                .orElseThrow(() -> new NoSuchTeamException(String.format("Team with id=\"%s\" does not exist", playerCreateRequest.getTeamId())));
+
+        Player player = Player.builder()
+                .firstName(playerCreateRequest.getFirstName())
+                .lastName(playerCreateRequest.getLastName())
+                .age(playerCreateRequest.getAge())
+                .monthsOfExperience(playerCreateRequest.getMonthsOfExperience())
+                .team(team)
+                .build();
+
+        return playerMapper.mapToPlayerDTO(playerRepository.save(player));
+    }
+
+    @Override
+    public Optional<PlayerDTO> getPlayerById(UUID playerId) {
+        return playerRepository.findById(playerId).map(playerMapper::mapToPlayerDTO);
+    }
+
+    @Override
+    public List<PlayerDTO> getAllPlayers() {
+        return playerMapper.mapAllToPlayerDTOList(playerRepository.findAll());
+    }
+
+    @Override
+    public PlayerDTO modifyPlayerById(UUID playerId, PlayerUpdateRequest playerUpdateRequest) throws NoSuchPlayerException {
+        Player player = playerRepository.findById(playerId)
+                .orElseThrow(() -> new NoSuchPlayerException(String.format("Player with id=\"%s\" does not exist", playerId)));
+
+        player.setFirstName(playerUpdateRequest.getFirstName());
+        player.setLastName(playerUpdateRequest.getLastName());
+        player.setAge(playerUpdateRequest.getAge());
+        player.setMonthsOfExperience(playerUpdateRequest.getMonthsOfExperience());
+
+        return playerMapper.mapToPlayerDTO(playerRepository.save(player));
+    }
+
+    @Override
+    public void removePlayerById(UUID playerId) throws NoSuchPlayerException {
+        if (!playerRepository.existsById(playerId)) {
+            throw new NoSuchPlayerException(String.format("Player with id=\"%s\" does not exist", playerId));
+        }
+
+        playerRepository.deleteById(playerId);
+    }
+}

--- a/src/main/java/ua/yatsergray/football/manager/service/impl/TeamServiceImpl.java
+++ b/src/main/java/ua/yatsergray/football/manager/service/impl/TeamServiceImpl.java
@@ -1,0 +1,78 @@
+package ua.yatsergray.football.manager.service.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import ua.yatsergray.football.manager.domain.dto.TeamDTO;
+import ua.yatsergray.football.manager.domain.entity.Team;
+import ua.yatsergray.football.manager.domain.request.TeamCreateUpdateRequest;
+import ua.yatsergray.football.manager.exception.NoSuchTeamException;
+import ua.yatsergray.football.manager.exception.TeamAlreadyExistsException;
+import ua.yatsergray.football.manager.mapper.TeamMapper;
+import ua.yatsergray.football.manager.repository.TeamRepository;
+import ua.yatsergray.football.manager.service.TeamService;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class TeamServiceImpl implements TeamService {
+    private final TeamMapper teamMapper;
+    private final TeamRepository teamRepository;
+
+    @Autowired
+    public TeamServiceImpl(TeamMapper teamMapper, TeamRepository teamRepository) {
+        this.teamMapper = teamMapper;
+        this.teamRepository = teamRepository;
+    }
+
+    @Override
+    public TeamDTO addTeam(TeamCreateUpdateRequest teamCreateUpdateRequest) throws TeamAlreadyExistsException {
+        if (teamRepository.existsByName(teamCreateUpdateRequest.getName())) {
+            throw new TeamAlreadyExistsException(String.format("Team with name=\"%s\" already exists", teamCreateUpdateRequest.getName()));
+        }
+
+        Team team = Team.builder()
+                .name(teamCreateUpdateRequest.getName())
+                .commissionPercentage(teamCreateUpdateRequest.getCommissionPercentage())
+                .bankAccountBalance(teamCreateUpdateRequest.getBankAccountBalance())
+                .build();
+
+        return teamMapper.mapToTeamDTO(teamRepository.save(team));
+    }
+
+    @Override
+    public Optional<TeamDTO> getTeamById(UUID teamId) {
+        return teamRepository.findById(teamId).map(teamMapper::mapToTeamDTO);
+    }
+
+    @Override
+    public List<TeamDTO> getAllTeams() {
+        return teamMapper.mapAllToTeamDTOList(teamRepository.findAll());
+    }
+
+    @Override
+    public TeamDTO modifyTeamById(UUID teamId, TeamCreateUpdateRequest teamCreateUpdateRequest) throws NoSuchTeamException, TeamAlreadyExistsException {
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new NoSuchTeamException(String.format("Team with id=\"%s\" does not exist", teamId)));
+
+        if (!teamCreateUpdateRequest.getName().equals(team.getName()) && teamRepository.existsByName(teamCreateUpdateRequest.getName())) {
+            throw new TeamAlreadyExistsException(String.format("Team with name=\"%s\" already exists", teamCreateUpdateRequest.getName()));
+        }
+
+        team.setName(teamCreateUpdateRequest.getName());
+        team.setCommissionPercentage(teamCreateUpdateRequest.getCommissionPercentage());
+        team.setBankAccountBalance(teamCreateUpdateRequest.getBankAccountBalance());
+
+        return teamMapper.mapToTeamDTO(teamRepository.save(team));
+    }
+
+    @Override
+    public void removeTeamById(UUID teamId) throws NoSuchTeamException {
+        if (!teamRepository.existsById(teamId)) {
+            throw new NoSuchTeamException(String.format("Team with id=\"%s\" does not exist", teamId));
+        }
+
+        teamRepository.deleteById(teamId);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,13 @@
 spring.application.name=FootballManager
+
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.datasource.url=jdbc:postgresql://localhost:5432/football_manager_db
+spring.datasource.username=postgres
+spring.datasource.password=yatsergray
+
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.show-sql=true
+
+spring.flyway.baseline-on-migrate=true
+spring.flyway.baseline-version=0

--- a/src/main/resources/db/migration/V0_1__drop_constraint.sql
+++ b/src/main/resources/db/migration/V0_1__drop_constraint.sql
@@ -1,0 +1,2 @@
+alter table if exists players
+    drop constraint if exists fk_player_team_id;

--- a/src/main/resources/db/migration/V0_2__drop_table.sql
+++ b/src/main/resources/db/migration/V0_2__drop_table.sql
@@ -1,0 +1,2 @@
+drop table if exists players cascade;
+drop table if exists teams cascade;

--- a/src/main/resources/db/migration/V0_3__create_table.sql
+++ b/src/main/resources/db/migration/V0_3__create_table.sql
@@ -1,0 +1,19 @@
+create table players
+(
+    id                   uuid         not null,
+    team_id              uuid         not null,
+    age                  integer      not null,
+    months_of_experience integer      not null,
+    first_name           varchar(255) not null,
+    last_name            varchar(255) not null,
+    primary key (id)
+);
+
+create table teams
+(
+    id                    uuid           not null,
+    bank_account_balance  numeric(19, 2) not null,
+    commission_percentage integer        not null,
+    name                  varchar(255)   not null unique,
+    primary key (id)
+);

--- a/src/main/resources/db/migration/V0_4__create_constraint.sql
+++ b/src/main/resources/db/migration/V0_4__create_constraint.sql
@@ -1,0 +1,2 @@
+alter table if exists players
+    add constraint fk_player_team_id foreign key (team_id) references teams;

--- a/src/main/resources/db/migration/V0_5__insert_into_table.sql
+++ b/src/main/resources/db/migration/V0_5__insert_into_table.sql
@@ -1,0 +1,17 @@
+insert into teams (id, name, commission_percentage, bank_account_balance)
+values
+    ('ae204b8f-7fa3-46bd-a2c2-165e88d50eb9', 'Dynamo Kyiv', 5, 1000000.00),
+    ('55c2bf52-1af1-44e4-9402-b435d2e09932', 'Shakhtar Donetsk', 7, 1500000.00);
+
+insert into players (id, first_name, last_name, age, months_of_experience, team_id)
+values
+    ('4d129aae-fec3-4cb1-88b3-ff1a4587bbb8', 'Georgiy', 'Bushchan', 29, 120, 'ae204b8f-7fa3-46bd-a2c2-165e88d50eb9'),
+    ('91f88268-f46f-4ca9-bb22-0ee6a9cb57a5', 'Oleksandr', 'Tymchyk', 26, 96, 'ae204b8f-7fa3-46bd-a2c2-165e88d50eb9'),
+    ('875d3f1b-1419-4743-b623-25ecc676314d', 'Denys', 'Popov', 24, 72, 'ae204b8f-7fa3-46bd-a2c2-165e88d50eb9'),
+    ('d9c80d95-ca4d-46b0-b043-2aef052bfd0f', 'Vitaliy', 'Buyalskyi', 30, 144, 'ae204b8f-7fa3-46bd-a2c2-165e88d50eb9'),
+    ('907d1b56-7e83-4835-955d-bc799de76142', 'Vladyslav', 'Vanat', 21, 48, 'ae204b8f-7fa3-46bd-a2c2-165e88d50eb9'),
+    ('26a0486b-c6b8-4da6-91e8-c400fe2a3e04', 'Dmytro', 'Riznyk', 26, 96, '55c2bf52-1af1-44e4-9402-b435d2e09932'),
+    ('46b11c29-273b-4e3a-b57a-3d6283c1b730', 'Yukhym', 'Konoplia', 24, 72, '55c2bf52-1af1-44e4-9402-b435d2e09932'),
+    ('cf16cee8-f860-45ab-824d-7ee9c14c278b', 'Mykola', 'Matviyenko', 27, 108, '55c2bf52-1af1-44e4-9402-b435d2e09932'),
+    ('8f00589e-cec9-4c58-b0de-cc895a9efb14', 'Oleksandr', 'Zubkov', 26, 96, '55c2bf52-1af1-44e4-9402-b435d2e09932'),
+    ('5b635ceb-ac91-4814-bee9-87f75d72bdc2', 'Danylo', 'Sikan', 22, 60, '55c2bf52-1af1-44e4-9402-b435d2e09932');


### PR DESCRIPTION
Added five REST API endpoints for the Team entity to cover CRUD operations:
- POST /api/v1/teams: Create team
- GET /api/v1/teams/{teamId}: Read team by ID
- GET /api/v1/teams: Read all teams
- PUT /api/v1/teams/{teamId}: Update team by ID
- DELETE /api/v1/teams/{teamId}: Delete team by ID

Added five REST API endpoints for the Player entity to cover CRUD operations:
- POST /api/v1/players: Create player
- GET /api/v1/players/{playerId}: Read player by ID
- GET /api/v1/players: Read all players
- PUT /api/v1/players/{playerId}: Update player by ID
- DELETE /api/v1/players/{playerId}: Delete player by ID